### PR TITLE
Pass arguments of original function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+yarn.lock

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import {AsyncMapCache, MemoizedFunction} from "./types";
 import {AsyncMap} from "./maps";
 
-export function mmemoize<S, T extends (...args: any[]) => Promise<S>>(func: T, opts: {resolver?: (...args: any[]) => string, map?: AsyncMapCache, namespace?: string} = {}): T & MemoizedFunction {
-    const memoized = (async (...args: any[]): Promise<S> => {
+export function mmemoize<S, T extends (args: any) => Promise<S>>(func: T, opts: { resolver?: (...args: any[]) => string, map?: AsyncMapCache, namespace?: string } = {}): T & MemoizedFunction {
+    const memoized = (async (args: any): Promise<S> => {
         const { resolver, namespace } = opts
-        const key = resolver ? resolver(args) : String(args[0])
+        const key = resolver ? resolver(args) : String(arguments[0])
 
         const cache = memoized.cache
 
@@ -13,7 +13,7 @@ export function mmemoize<S, T extends (...args: any[]) => Promise<S>>(func: T, o
             return value
         }
 
-        const result = await func()
+        const result = await func(args)
         await cache.set(key, result, namespace)
 
         return result

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
 import {AsyncMapCache, MemoizedFunction} from "./types";
 import {AsyncMap} from "./maps";
 
-export function mmemoize<S, T extends (args: any) => Promise<S>>(func: T, opts: { resolver?: (...args: any[]) => string, map?: AsyncMapCache, namespace?: string } = {}): T & MemoizedFunction {
-    const memoized = (async (args: any): Promise<S> => {
+export function mmemoize<S, T extends (...args: any[]) => Promise<S>>(func: T, opts: { resolver?: (...args: any[]) => string, map?: AsyncMapCache, namespace?: string } = {}): T & MemoizedFunction {
+    async function memoized(_: any): Promise<S> {
         const { resolver, namespace } = opts
-        const key = resolver ? resolver(args) : String(arguments[0])
+        const key = resolver ? resolver(...arguments) : String(arguments[0]);
 
         const cache = memoized.cache
 
@@ -13,15 +13,15 @@ export function mmemoize<S, T extends (args: any) => Promise<S>>(func: T, opts: 
             return value
         }
 
-        const result = await func(args)
+        const result = await func(...arguments);
         await cache.set(key, result, namespace)
 
         return result
-    }) as T & MemoizedFunction
+    }
 
     memoized.cache = opts?.map || new AsyncMap()
 
-    return memoized
+    return memoized as T & MemoizedFunction;
 }
 
 export default mmemoize

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import {AsyncMapCache, MemoizedFunction} from "./types";
 import {AsyncMap} from "./maps";
 
 export function mmemoize<S, T extends (...args: any[]) => Promise<S>>(func: T, opts: { resolver?: (...args: any[]) => string, map?: AsyncMapCache, namespace?: string } = {}): T & MemoizedFunction {
-    async function memoized(_: any): Promise<S> {
+    async function memoized(...args: any[]): Promise<S> {
         const { resolver, namespace } = opts
-        const key = resolver ? resolver(...arguments) : String(arguments[0]);
+        const key = resolver ? resolver(...args) : String(args[0]);
 
         const cache = memoized.cache
 
@@ -13,7 +13,7 @@ export function mmemoize<S, T extends (...args: any[]) => Promise<S>>(func: T, o
             return value
         }
 
-        const result = await func(...arguments);
+        const result = await func(...args);
         await cache.set(key, result, namespace)
 
         return result

--- a/src/maps/memcachedMap.test.ts
+++ b/src/maps/memcachedMap.test.ts
@@ -1,5 +1,5 @@
 import {MemcachedMap} from "./";
-import * as Memcached from "memcached";
+import Memcached from "memcached";
 
 test('MemcachedMap', async () => {
     const map = new MemcachedMap(new Memcached("127.0.0.1:11211"))

--- a/src/mmemoize.test.ts
+++ b/src/mmemoize.test.ts
@@ -1,7 +1,8 @@
 import mmemoize from "./index";
 import {AsyncMap} from "./maps/AsyncMap";
 
-const counter = (x: number) => {return (async () => {return x += 1})}
+const echo = async (x: string) => { return x }
+const counter = (x: number) => { return (async () => { return x += 1 }) }
 
 function sleep(waitMilliSec: number) {
     return new Promise(function (resolve) {
@@ -17,6 +18,14 @@ test('mmemoize basic', async () => {
     const y = mmemoize(counter(3))
     expect(await y()).toBe(4)
     expect(await y()).toBe(4)
+});
+
+test('mmemoize with argument', async () => {
+    expect(await echo('awesome')).toBe('awesome')
+
+    const y = mmemoize(echo)
+    expect(await y('awesome')).toBe('awesome')
+    expect(await y('great')).toBe('awesome')
 });
 
 test('mmemoize with expire', async () => {

--- a/src/mmemoize.test.ts
+++ b/src/mmemoize.test.ts
@@ -25,7 +25,7 @@ test('mmemoize with argument', async () => {
 
     const y = mmemoize(echo)
     expect(await y('awesome')).toBe('awesome')
-    expect(await y('great')).toBe('awesome')
+    expect(await(await y.cache.get("awesome")).value).toBe("awesome");
 });
 
 test('mmemoize with expire', async () => {
@@ -35,4 +35,13 @@ test('mmemoize with expire', async () => {
 
     await sleep(2 * 1000)
     expect(await y()).toBe(5)
+});
+
+test("mmemoize with argument and expire", async () => {
+    const y = mmemoize(echo, { map: new AsyncMap({ expire: 1 * 1000 }) });
+    expect(await y("awesome")).toBe("awesome");
+    expect(await (await y.cache.get("awesome")).value).toBe("awesome");
+
+    await sleep(2 * 1000);
+    expect(await(await y.cache.get("awesome")).value).toBe(undefined);
 });


### PR DESCRIPTION
`mmemoize` doesn't use arguments passed to original functions.
Following code is to reproduce the situation.

```typescript
const fetch = mmemoize(
  async (userId: string): Promise<string> => {
    console.log('userId: ', userId)
    return userId
  }
)

const result = await fetch('userId')
console.log(result) 
// => undefined  <- this should be 'userId'
```